### PR TITLE
convert crate to fully async behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,12 +879,12 @@ dependencies = [
  "env_logger",
  "fallible-iterator",
  "fancy-regex",
+ "futures",
  "hdf5",
  "kdam",
  "lazy_static",
  "log",
  "murmur3",
- "postgres",
  "refinery",
  "scylla",
  "serde",
@@ -892,6 +892,7 @@ dependencies = [
  "serial_test",
  "sysinfo",
  "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -1140,20 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
-name = "postgres"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bed5017bc2ff49649c0075d0d7a9d676933c1292480c1d137776fb205b5cd18"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,12 +1330,13 @@ dependencies = [
  "cfg-if",
  "lazy_static",
  "log",
- "postgres",
  "regex",
  "serde",
  "siphasher",
  "thiserror",
  "time 0.3.20",
+ "tokio",
+ "tokio-postgres",
  "toml",
  "url",
  "walkdir",
@@ -1561,6 +1549,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1802,7 +1799,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.3.0", features = ["derive"] }
 env_logger = "0.10.0"
 fallible-iterator = "0.2.0"
 fancy-regex = "0.11.0"
+futures = "0.3.28"
 # Support for hdf4 1.15. If PR https://github.com/aldanor/hdf5-rust/pull/227 is accepted, this can be removed
 hdf5 = { git = "https://github.com/mulimoen/hdf5-rust.git", branch = "feature/hdf5_1_14"}
 # hdf5 = "0.8.1"
@@ -29,13 +30,13 @@ kdam = "0.3.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
 murmur3 = "0.5.2"
-postgres = { version = "0.19.4", features = ["with-serde_json-1"] }
-refinery = { version = "0.8.7", features = ["postgres"] }
+refinery = { version = "0.8.7", features = ["tokio-postgres"] }
 scylla = "0.8.1"
 serde = "1.0.160"
 serde_json = "1.0.95"
 sysinfo = "0.28.2"
-tokio = "1.28.2"
+tokio = { version = "1.28.2", features = ["full"] }
+tokio-postgres = { version = "0.7.8", features = ["with-serde_json-1"] }
 
 [dev-dependencies]
 serial_test = "*"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# use nightly until async traits are stable
+channel = "nightly"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+// 3rd party imports
 use clap::{Parser, Subcommand};
 use log::info;
 use macpepdb::{
@@ -32,7 +33,8 @@ struct Cli {
     command: Commands,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     info!("Welcome to MaCPepDB!");
 
@@ -53,7 +55,7 @@ fn main() {
             verbose,
         } => {
             let builder = DatabaseBuild::new(database_url);
-            builder
+            match builder
                 .build(
                     &protein_file_paths,
                     num_threads,
@@ -64,7 +66,11 @@ fn main() {
                     show_progress,
                     verbose,
                 )
-                .unwrap();
+                .await
+            {
+                Ok(_) => info!("Database build completed successfully!"),
+                Err(e) => info!("Database build failed: {}", e),
+            }
         }
     }
 }

--- a/src/database/citus/configuration_table.rs
+++ b/src/database/citus/configuration_table.rs
@@ -1,8 +1,8 @@
 // 3rd party imports
 use anyhow::{anyhow, Result};
-use postgres::GenericClient;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_json::{from_value as from_json_value, json, Value as JsonValue};
+use tokio_postgres::GenericClient;
 
 // internal imports
 use crate::database::configuration_table::{
@@ -29,14 +29,14 @@ impl Table for ConfigurationTable {
 
 impl<C> ConfigurationTableTrait<C> for ConfigurationTable
 where
-    C: GenericClient,
+    C: GenericClient + Send,
 {
-    fn get_setting<T>(client: &mut C, key: &str) -> Result<Option<T>>
+    async fn get_setting<T>(client: &C, key: &str) -> Result<Option<T>>
     where
         T: DeserializeOwned,
     {
         let statement = format!("SELECT value FROM {} WHERE conf_key = $1;", TABLE_NAME);
-        match client.query_opt(&statement, &[&key])? {
+        match client.query_opt(&statement, &[&key]).await? {
             Some(row) => {
                 let mut wrapper: JsonValue = row.get(0);
                 let value = match wrapper.get_mut(JSON_KEY) {
@@ -49,53 +49,57 @@ where
         }
     }
 
-    fn set_setting<T>(client: &mut C, key: &str, value: &T) -> Result<()>
+    async fn set_setting<T>(client: &C, key: &str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: Serialize + Sync,
     {
         let statement = format!(
             "INSERT INTO {} (conf_key, value) VALUES ($1, $2);",
             TABLE_NAME
         );
         let wrapper = json!({ JSON_KEY: value });
-        client.execute(&statement, &[&key, &wrapper])?;
+        client.execute(&statement, &[&key, &wrapper]).await?;
         Ok(())
     }
 
-    fn select(client: &mut C) -> Result<Configuration>
+    async fn select(client: &C) -> Result<Configuration>
     where
         C: GenericClient,
     {
-        let enzyme_name = Self::get_setting::<String>(client, ENZYME_NAME_KEY)?
+        let enzyme_name = Self::get_setting::<String>(client, ENZYME_NAME_KEY)
+            .await?
             .ok_or_else(|| anyhow!(ConfigurationIncompleteError::new(ENZYME_NAME_KEY)))?;
 
         let max_number_of_missed_cleavages =
-            Self::get_setting::<i16>(client, MAX_NUMBER_OF_MISSED_CLEAVAGES_KEY)?.ok_or_else(
-                || {
+            Self::get_setting::<i16>(client, MAX_NUMBER_OF_MISSED_CLEAVAGES_KEY)
+                .await?
+                .ok_or_else(|| {
                     anyhow!(ConfigurationIncompleteError::new(
                         MAX_NUMBER_OF_MISSED_CLEAVAGES_KEY
                     ))
-                },
-            )?;
+                })?;
 
-        let min_peptide_length = Self::get_setting::<i16>(client, MIN_PEPTIDE_LENGTH_KEY)?
+        let min_peptide_length = Self::get_setting::<i16>(client, MIN_PEPTIDE_LENGTH_KEY)
+            .await?
             .ok_or_else(|| anyhow!(ConfigurationIncompleteError::new(MIN_PEPTIDE_LENGTH_KEY)))?;
 
-        let max_peptide_length = Self::get_setting::<i16>(client, MAX_PEPTIDE_LENGTH_KEY)?
+        let max_peptide_length = Self::get_setting::<i16>(client, MAX_PEPTIDE_LENGTH_KEY)
+            .await?
             .ok_or_else(|| anyhow!(ConfigurationIncompleteError::new(MAX_PEPTIDE_LENGTH_KEY)))?;
 
         // remove_peptides_containing_unknown
         let remove_peptides_containing_unknown =
-            Self::get_setting::<bool>(client, REMOVE_PEPTIDES_CONTAINING_UNKNOWN_KEY)?.ok_or_else(
-                || {
+            Self::get_setting::<bool>(client, REMOVE_PEPTIDES_CONTAINING_UNKNOWN_KEY)
+                .await?
+                .ok_or_else(|| {
                     anyhow!(ConfigurationIncompleteError::new(
                         REMOVE_PEPTIDES_CONTAINING_UNKNOWN_KEY
                     ))
-                },
-            )?;
+                })?;
 
         // remove_peptides_containing_unknown
-        let partition_limits = Self::get_setting::<Vec<i64>>(client, PARTITION_LIMITS_KEY)?
+        let partition_limits = Self::get_setting::<Vec<i64>>(client, PARTITION_LIMITS_KEY)
+            .await?
             .ok_or_else(|| anyhow!(ConfigurationIncompleteError::new(PARTITION_LIMITS_KEY)))?;
 
         Ok(Configuration::new(
@@ -108,46 +112,52 @@ where
         ))
     }
 
-    fn insert(client: &mut C, configuration: &Configuration) -> Result<()> {
-        let mut transaction = client.transaction()?;
+    async fn insert(client: &mut C, configuration: &Configuration) -> Result<()> {
+        let transaction = client.transaction().await?;
 
         ConfigurationTable::set_setting::<String>(
-            &mut transaction,
+            &transaction,
             ENZYME_NAME_KEY,
             &configuration.get_enzyme_name().to_owned(),
-        )?;
+        )
+        .await?;
 
         ConfigurationTable::set_setting::<i16>(
-            &mut transaction,
+            &transaction,
             MAX_NUMBER_OF_MISSED_CLEAVAGES_KEY,
             &(configuration.get_max_number_of_missed_cleavages() as i16),
-        )?;
+        )
+        .await?;
 
         ConfigurationTable::set_setting::<i16>(
-            &mut transaction,
+            &transaction,
             MIN_PEPTIDE_LENGTH_KEY,
             &(configuration.get_min_peptide_length() as i16),
-        )?;
+        )
+        .await?;
 
         ConfigurationTable::set_setting::<i16>(
-            &mut transaction,
+            &transaction,
             MAX_PEPTIDE_LENGTH_KEY,
             &(configuration.get_max_peptide_length() as i16),
-        )?;
+        )
+        .await?;
 
         ConfigurationTable::set_setting::<bool>(
-            &mut transaction,
+            &transaction,
             REMOVE_PEPTIDES_CONTAINING_UNKNOWN_KEY,
             &configuration.get_remove_peptides_containing_unknown(),
-        )?;
+        )
+        .await?;
 
         ConfigurationTable::set_setting::<Vec<i64>>(
-            &mut transaction,
+            &transaction,
             PARTITION_LIMITS_KEY,
             configuration.get_partition_limits(),
-        )?;
+        )
+        .await?;
 
-        transaction.commit()?;
+        transaction.commit().await?;
 
         Ok(())
     }
@@ -176,27 +186,48 @@ mod tests {
     /// Tests selecting without inserting first.
     /// Should result in an `ConfigurationIncompleteError`.
     ///
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn test_select_without_insert() {
-        prepare_database_for_tests();
-        let mut client = get_client();
+    async fn test_select_without_insert() {
+        let (mut client, connection) = get_client().await;
 
-        let configuration_res = ConfigurationTable::select(&mut client);
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        let connection_handle = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        prepare_database_for_tests(&mut client).await;
+
+        let configuration_res = ConfigurationTable::select(&client).await;
 
         assert!(configuration_res.is_err());
         assert!(configuration_res
             .unwrap_err()
             .is::<ConfigurationIncompleteError>());
+
+        connection_handle.abort();
+        let _ = connection_handle.await;
     }
 
     /// Tests inserting
+    /// Unfortunately you cannot call an async test from another async test. So we need outsource the implementation,
+    /// as other tests depends on it
     ///
-    #[test]
-    #[serial]
-    fn test_insert() {
-        prepare_database_for_tests();
-        let mut client = get_client();
+    async fn test_insert_internal() {
+        let (mut client, connection) = get_client().await;
+
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        let connection_handle = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        prepare_database_for_tests(&mut client).await;
 
         let configuration = Configuration::new(
             EXPECTED_ENZYME_NAME.to_owned(),
@@ -207,18 +238,39 @@ mod tests {
             EXPECTED_PARTITION_LIMITS.clone(),
         );
 
-        ConfigurationTable::insert(&mut client, &configuration).unwrap();
+        ConfigurationTable::insert(&mut client, &configuration)
+            .await
+            .unwrap();
+
+        connection_handle.abort();
+        let _ = connection_handle.await;
+    }
+
+    /// Tests inserting
+    ///
+    #[tokio::test]
+    #[serial]
+    async fn test_insert() {
+        test_insert_internal().await;
     }
 
     /// Tests selecting after inserting
     ///
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn test_select() {
-        test_insert();
-        let mut client = get_client();
+    async fn test_select() {
+        test_insert_internal().await;
+        let (client, connection) = get_client().await;
 
-        let configuration = ConfigurationTable::select(&mut client).unwrap();
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        let connection_handle = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        let configuration = ConfigurationTable::select(&client).await.unwrap();
 
         assert_eq!(configuration.get_enzyme_name(), EXPECTED_ENZYME_NAME);
         assert_eq!(
@@ -241,5 +293,8 @@ mod tests {
             configuration.get_partition_limits(),
             EXPECTED_PARTITION_LIMITS.as_slice()
         );
+
+        connection_handle.abort();
+        let _ = connection_handle.await;
     }
 }

--- a/src/database/configuration_table.rs
+++ b/src/database/configuration_table.rs
@@ -48,7 +48,7 @@ pub trait ConfigurationTable<C>: Table {
     /// * `client` - A database client
     /// * `key` - The key to look up
     ///
-    fn get_setting<T>(client: &mut C, key: &str) -> Result<Option<T>>
+    async fn get_setting<T>(client: &C, key: &str) -> Result<Option<T>>
     where
         T: DeserializeOwned;
 
@@ -59,16 +59,16 @@ pub trait ConfigurationTable<C>: Table {
     /// * `key` - The key to look up
     /// * `value` - The value to save
     ///
-    fn set_setting<T>(client: &mut C, key: &str, value: &T) -> Result<()>
+    async fn set_setting<T>(client: &C, key: &str, value: &T) -> Result<()>
     where
-        T: Serialize;
+        T: Serialize + Sync;
 
     /// Selects the configuration from the database.
     ///
     /// # Arguments
     /// * `client` - A database client
     ///
-    fn select(client: &mut C) -> Result<Configuration>;
+    async fn select(client: &C) -> Result<Configuration>;
 
     /// Inserts the configuration into the database.
     ///
@@ -76,5 +76,5 @@ pub trait ConfigurationTable<C>: Table {
     /// * `client` - A database client
     /// * `configuration` - The configuration to insert
     ///
-    fn insert(client: &mut C, configuration: &Configuration) -> Result<()>;
+    async fn insert(client: &mut C, configuration: &Configuration) -> Result<()>;
 }

--- a/src/database/database_build.rs
+++ b/src/database/database_build.rs
@@ -32,7 +32,7 @@ pub trait DatabaseBuild {
     /// * `show_progress` - Whether to show progress.
     /// * `verbose` - Whether to show verbose output.
     ///
-    fn build(
+    async fn build(
         &self,
         protein_file_paths: &Vec<PathBuf>,
         num_threads: usize,

--- a/src/database/scylla/client.rs
+++ b/src/database/scylla/client.rs
@@ -1,7 +1,11 @@
-use scylla::transport::session::Session;
+// 3rd party imports
+use anyhow::Result;
+use scylla::{transport::session::Session, SessionBuilder};
 
 pub trait GenericClient {
-    fn new(session: Session) -> Self;
+    async fn new(database_url: &str) -> Result<Self>
+    where
+        Self: Sized;
     fn get_session(&self) -> &Session;
 }
 
@@ -10,8 +14,16 @@ pub struct Client {
 }
 
 impl GenericClient for Client {
-    fn new(session: Session) -> Self {
-        Self { session }
+    async fn new(database_url: &str) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            session: SessionBuilder::new()
+                .known_node(database_url)
+                .build()
+                .await?,
+        })
     }
 
     fn get_session(&self) -> &Session {

--- a/src/database/scylla/mod.rs
+++ b/src/database/scylla/mod.rs
@@ -5,25 +5,30 @@ pub mod migrations;
 
 #[cfg(test)]
 mod tests {
+
+    // 3rd party imports
+    use anyhow::Result;
+
+    // internal imports
+    use crate::database::scylla::client::{Client, GenericClient};
     use crate::database::scylla::migrations::{DROP_KEYSPACE, UP};
-    use scylla::{transport::session::Session, SessionBuilder};
 
     pub const DATABASE_URL: &str = "127.0.0.1:9042";
     // let uri = env::var("SCYLLA_URI").unwrap_or_else(|_| DATABASE_URL.to_string());
-    pub async fn get_session() -> Session {
-        return SessionBuilder::new()
-            .known_node(DATABASE_URL)
-            .build()
-            .await
-            .unwrap();
+    pub async fn get_client() -> Result<Client> {
+        Client::new(DATABASE_URL).await
     }
 
-    pub async fn prepare_database_for_tests(session: &Session) {
+    pub async fn prepare_database_for_tests(client: &Client) {
         // Dropping a keyspace automatically drops all contained tables
-        session.query(DROP_KEYSPACE, &[]).await.unwrap();
+        client
+            .get_session()
+            .query(DROP_KEYSPACE, &[])
+            .await
+            .unwrap();
 
         for statement in UP {
-            session.query(statement, &[]).await.unwrap();
+            client.get_session().query(statement, &[]).await.unwrap();
         }
     }
 }

--- a/src/entities/peptide.rs
+++ b/src/entities/peptide.rs
@@ -6,7 +6,7 @@ use std::{
 
 // 3rd party imports
 use anyhow::Result;
-use postgres::Row;
+use tokio_postgres::Row;
 
 // internal imports
 use crate::entities::protein::Protein;

--- a/src/entities/protein.rs
+++ b/src/entities/protein.rs
@@ -1,5 +1,5 @@
 // 3rd party imports
-use postgres::Row;
+use tokio_postgres::Row;
 
 #[derive(Clone)]
 /// Keeps all data from the original UniProt entry which are necessary for MaCPepDB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 // # Create absolute path to readme ti increase compatible for different build targets
 //  https://gist.github.com/JakeHartnell/2c1fa387f185f5dc46c9429470a2e2be
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Readme.md"))]
+// Going nightly for now to use async traits and related features
+// Accoirding to [this article](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html)
+// the feature should be stable in 1.74 (estimated)
+#![feature(async_fn_in_trait)]
+#![feature(impl_trait_projections)]
+#![feature(trait_alias)]
+#![feature(type_alias_impl_trait)]
+#![feature(async_iterator)]
 
 // 3rd party imports
 #[allow(unused_imports)]


### PR DESCRIPTION
Implemented  fully async behavior by:
* switching to nighty get support for `async-traits` and related features which should get stable this year (2023)
* change from `postgres` to `tokio_postgres` 
* making all test async by using `tokio::test`
* Runtime is now `tokio`

Things I could not figure out yet:
* `scylla` and `tokio_postgres` are using Stream implementation to iterate of multiple rows in an asynchronous manner. I would like to implement a Stream to convert the row stream into an entity stream. I had no luck making this work due to incompatible pinning references. Will look into this later. For now we do not need that feature an may drop this in the future as a server side cursor is much more useful for limiting and the returned results.